### PR TITLE
Fix bug with some GraphQL apis

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -58,11 +58,16 @@ class Client
      */
     public function raw($query, $variables = [], $headers = [])
     {
+        $json = [
+            'query' => $query,
+        ];
+
+        if (!empty($variables)) {
+            $json['variables'] = $variables;
+        }
+
         return $this->guzzle->request('POST', $this->url, [
-            'json' => [
-                'query' => $query,
-                'variables' => $variables
-            ],
+            'json' => $json,
             'headers' => $headers
         ]);
     }


### PR DESCRIPTION
Hasura does not like empty variables. 

This commit fixes: "parsing HashMap failed, expected Object, but encountered Array"